### PR TITLE
Update to only show on Zen and clean up formatting.

### DIFF
--- a/chrome.css
+++ b/chrome.css
@@ -1,506 +1,499 @@
-@-moz-document url-prefix("chrome:") {
-    @media (-moz-bool-pref: "zen.tabs.vertical") {
+/* Essentials icon size */
+:root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="16px"]) {
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
+    .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
+        height: 16px !important;
+        width: 16px !important;
+    }
+}
 
-        /* Essentials icon size */
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="16px"]) {
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
-            .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
-                height: 16px !important;
-                width: 16px !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="18px"]) {
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
+    .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
+        height: 18px !important;
+        width: 18px !important;
+    }
+    .tabbrowser-tab[zen-essential="true"] .tab-throbber {
+        transform: scale(1.125) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="18px"]) {
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
-            .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
-                height: 18px !important;
-                width: 18px !important;
-            }
-            .tabbrowser-tab[zen-essential="true"] .tab-throbber {
-                transform: scale(1.125) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="20px"]) {
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
+    .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
+        height: 20px !important;
+        width: 20px !important;
+    }
+    .tabbrowser-tab[zen-essential="true"] .tab-throbber {
+        transform: scale(1.25) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="20px"]) {
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
-            .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
-                height: 20px !important;
-                width: 20px !important;
-            }
-            .tabbrowser-tab[zen-essential="true"] .tab-throbber {
-                transform: scale(1.25) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="22px"]) {
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
+    .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
+        height: 22px !important;
+        width: 22px !important;
+    }
+    .tabbrowser-tab[zen-essential="true"] .tab-throbber {
+        transform: scale(1.375) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="22px"]) {
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
-            .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
-                height: 22px !important;
-                width: 22px !important;
-            }
-            .tabbrowser-tab[zen-essential="true"] .tab-throbber {
-                transform: scale(1.375) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="24px"]) {
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
+    .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
+        height: 24px !important;
+        width: 24px !important;
+    }
+    .tabbrowser-tab[zen-essential="true"] .tab-throbber {
+        transform: scale(1.5) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="24px"]) {
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
-            .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
-                height: 24px !important;
-                width: 24px !important;
-            }
-            .tabbrowser-tab[zen-essential="true"] .tab-throbber {
-                transform: scale(1.5) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="26px"]) {
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
+    .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
+        height: 26px !important;
+        width: 26px !important;
+    }
+    .tabbrowser-tab[zen-essential="true"] .tab-throbber {
+        transform: scale(1.625) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="26px"]) {
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
-            .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
-                height: 26px !important;
-                width: 26px !important;
-            }
-            .tabbrowser-tab[zen-essential="true"] .tab-throbber {
-                transform: scale(1.625) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="28px"]) {
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
+    .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
+        height: 28px !important;
+        width: 28px !important;
+    }
+    .tabbrowser-tab[zen-essential="true"] .tab-throbber {
+        transform: scale(1.75) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="28px"]) {
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
-            .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
-                height: 28px !important;
-                width: 28px !important;
-            }
-            .tabbrowser-tab[zen-essential="true"] .tab-throbber {
-                transform: scale(1.75) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="30px"]) {
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
+    .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
+        height: 30px !important;
+        width: 30px !important;
+    }
+    .tabbrowser-tab[zen-essential="true"] .tab-throbber {
+        transform: scale(1.875) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="30px"]) {
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
-            .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
-                height: 30px !important;
-                width: 30px !important;
-            }
-            .tabbrowser-tab[zen-essential="true"] .tab-throbber {
-                transform: scale(1.875) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="32px"]) {
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
+    .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
+        height: 32px !important;
+        width: 32px !important;
+    }
+    .tabbrowser-tab[zen-essential="true"] .tab-throbber {
+        transform: scale(2) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="32px"]) {
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
-            .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
-                height: 32px !important;
-                width: 32px !important;
-            }
-            .tabbrowser-tab[zen-essential="true"] .tab-throbber {
-                transform: scale(2) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="34px"]) {
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
+    .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
+        height: 34px !important;
+        width: 34px !important;
+    }
+    .tabbrowser-tab[zen-essential="true"] .tab-throbber {
+        transform: scale(2.125) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="34px"]) {
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
-            .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
-                height: 34px !important;
-                width: 34px !important;
-            }
-            .tabbrowser-tab[zen-essential="true"] .tab-throbber {
-                transform: scale(2.125) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="36px"]) {
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
+    .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
+        height: 36px !important;
+        width: 36px !important;
+    }
+    .tabbrowser-tab[zen-essential="true"] .tab-throbber {
+        transform: scale(2.15) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="36px"]) {
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
-            .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
-                height: 36px !important;
-                width: 36px !important;
-            }
-            .tabbrowser-tab[zen-essential="true"] .tab-throbber {
-                transform: scale(2.15) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="38px"]) {
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
+    .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
+        height: 38px !important;
+        width: 38px !important;
+    }
+    .tabbrowser-tab[zen-essential="true"] .tab-throbber {
+        transform: scale(2.175) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="38px"]) {
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
-            .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
-                height: 38px !important;
-                width: 38px !important;
-            }
-            .tabbrowser-tab[zen-essential="true"] .tab-throbber {
-                transform: scale(2.175) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="40px"]) {
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
+    .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
+    .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
+        height: 40px !important;
+        width: 40px !important;
+    }
+    .tabbrowser-tab[zen-essential="true"] .tab-throbber {
+        transform: scale(2.2) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-essentials-icon-size="40px"]) {
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-pending,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-image,
-            .tabbrowser-tab[zen-essential="true"] .tab-sharing-icon-overlay,
-            .tabbrowser-tab[zen-essential="true"] .tab-icon-overlay {
-                height: 40px !important;
-                width: 40px !important;
-            }
-            .tabbrowser-tab[zen-essential="true"] .tab-throbber {
-                transform: scale(2.2) !important;
-            }
-        }
+/* Pinned tabs icon size */
+:root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="12px"]) {
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
+        height: 12px !important;
+        width: 12px !important;
+    }
+}
 
+:root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="14px"]) {
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
+        height: 14px !important;
+        width: 14px !important;
+    }
+}
 
-        /* Pinned tabs icon size */
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="12px"]) {
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
-                height: 12px !important;
-                width: 12px !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="16px"]) {
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
+        height: 16px !important;
+        width: 16px !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="14px"]) {
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
-                height: 14px !important;
-                width: 14px !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="18px"]) {
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
+        height: 18px !important;
+        width: 18px !important;
+    }
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-throbber {
+        transform: scale(1.125) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="16px"]) {
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
-                height: 16px !important;
-                width: 16px !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="20px"]) {
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
+        height: 20px !important;
+        width: 20px !important;
+    }
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-throbber {
+        transform: scale(1.25) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="18px"]) {
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
-                height: 18px !important;
-                width: 18px !important;
-            }
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-throbber {
-                transform: scale(1.125) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="22px"]) {
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
+        height: 22px !important;
+        width: 22px !important;
+    }
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-throbber {
+        transform: scale(1.375) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="20px"]) {
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
-                height: 20px !important;
-                width: 20px !important;
-            }
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-throbber {
-                transform: scale(1.25) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="24px"]) {
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
+        height: 24px !important;
+        width: 24px !important;
+    }
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-throbber {
+        transform: scale(1.5) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="22px"]) {
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
-                height: 22px !important;
-                width: 22px !important;
-            }
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-throbber {
-                transform: scale(1.375) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="26px"]) {
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
+        height: 26px !important;
+        width: 26px !important;
+    }
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-throbber {
+        transform: scale(1.625) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="24px"]) {
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
-                height: 24px !important;
-                width: 24px !important;
-            }
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-throbber {
-                transform: scale(1.5) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="28px"]) {
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
+        height: 28px !important;
+        width: 28px !important;
+    }
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-throbber {
+        transform: scale(1.75) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="26px"]) {
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
-                height: 26px !important;
-                width: 26px !important;
-            }
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-throbber {
-                transform: scale(1.625) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="30px"]) {
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
+        height: 30px !important;
+        width: 30px !important;
+    }
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-throbber {
+        transform: scale(1.875) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="28px"]) {
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
-                height: 28px !important;
-                width: 28px !important;
-            }
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-throbber {
-                transform: scale(1.75) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="32px"]) {
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
+        height: 32px !important;
+        width: 32px !important;
+    }
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-throbber {
+        transform: scale(2) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="30px"]) {
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
-                height: 30px !important;
-                width: 30px !important;
-            }
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-throbber {
-                transform: scale(1.875) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="34px"]) {
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
+        height: 34px !important;
+        width: 34px !important;
+    }
+    .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-throbber {
+        transform: scale(2.125) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="32px"]) {
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
-                height: 32px !important;
-                width: 32px !important;
-            }
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-throbber {
-                transform: scale(2) !important;
-            }
-        }
+/* Normal tabs icon size */
+:root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="12px"]) {
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
+        height: 12px !important;
+        width: 12px !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-pinned-icon-size="34px"]) {
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-icon-overlay {
-                height: 34px !important;
-                width: 34px !important;
-            }
-            .tabbrowser-tab[pinned]:not([zen-essential="true"]) .tab-throbber {
-                transform: scale(2.125) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="14px"]) {
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
+        height: 14px !important;
+        width: 14px !important;
+    }
+}
 
-        /* Normal tabs icon size */
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="12px"]) {
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
-                height: 12px !important;
-                width: 12px !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="16px"]) {
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
+        height: 16px !important;
+        width: 16px !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="14px"]) {
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
-                height: 14px !important;
-                width: 14px !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="18px"]) {
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
+        height: 18px !important;
+        width: 18px !important;
+    }
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-throbber {
+        transform: scale(1.125) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="16px"]) {
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
-                height: 16px !important;
-                width: 16px !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="20px"]) {
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
+        height: 20px !important;
+        width: 20px !important;
+    }
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-throbber {
+        transform: scale(1.25) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="18px"]) {
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
-                height: 18px !important;
-                width: 18px !important;
-            }
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-throbber {
-                transform: scale(1.125) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="22px"]) {
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
+        height: 22px !important;
+        width: 22px !important;
+    }
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-throbber {
+        transform: scale(1.375) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="20px"]) {
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
-                height: 20px !important;
-                width: 20px !important;
-            }
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-throbber {
-                transform: scale(1.25) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="24px"]) {
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
+        height: 24px !important;
+        width: 24px !important;
+    }
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-throbber {
+        transform: scale(1.5) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="22px"]) {
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
-                height: 22px !important;
-                width: 22px !important;
-            }
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-throbber {
-                transform: scale(1.375) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="26px"]) {
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
+        height: 26px !important;
+        width: 26px !important;
+    }
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-throbber {
+        transform: scale(1.625) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="24px"]) {
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
-                height: 24px !important;
-                width: 24px !important;
-            }
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-throbber {
-                transform: scale(1.5) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="28px"]) {
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
+        height: 28px !important;
+        width: 28px !important;
+    }
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-throbber {
+        transform: scale(1.75) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="26px"]) {
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
-                height: 26px !important;
-                width: 26px !important;
-            }
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-throbber {
-                transform: scale(1.625) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="30px"]) {
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
+        height: 30px !important;
+        width: 30px !important;
+    }
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-throbber {
+        transform: scale(1.875) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="28px"]) {
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
-                height: 28px !important;
-                width: 28px !important;
-            }
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-throbber {
-                transform: scale(1.75) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="32px"]) {
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
+        height: 32px !important;
+        width: 32px !important;
+    }
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-throbber {
+        transform: scale(2) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="30px"]) {
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
-                height: 30px !important;
-                width: 30px !important;
-            }
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-throbber {
-                transform: scale(1.875) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="34px"]) {
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
+        height: 34px !important;
+        width: 34px !important;
+    }
+    .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-throbber {
+        transform: scale(2.125) !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="32px"]) {
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
-                height: 32px !important;
-                width: 32px !important;
-            }
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-throbber {
-                transform: scale(2) !important;
-            }
-        }
+/* Workspace icons size */
+:root:has(#theme-Icon-Tweaker[icon-tweaker-workspace-icon-size="10px"]) {
+    #zen-workspaces-button {
+        font-size: 10px !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-normal-icon-size="34px"]) {
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-pending,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-image,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-sharing-icon-overlay,
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-icon-overlay {
-                height: 34px !important;
-                width: 34px !important;
-            }
-            .tabbrowser-tab:not([pinned]):not([zen-essential="true"]) .tab-throbber {
-                transform: scale(2.125) !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-workspace-icon-size="12px"]) {
+    #zen-workspaces-button {
+        font-size: 12px !important;
+    }
+}
 
-        /* Workspace icons size */
+:root:has(#theme-Icon-Tweaker[icon-tweaker-workspace-icon-size="14px"]) {
+    #zen-workspaces-button {
+        font-size: 14px !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-workspace-icon-size="10px"]) {
-            #zen-workspaces-button {
-                font-size: 10px !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-workspace-icon-size="16px"]) {
+    #zen-workspaces-button {
+        font-size: 16px !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-workspace-icon-size="12px"]) {
-            #zen-workspaces-button {
-                font-size: 12px !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-workspace-icon-size="18px"]) {
+    #zen-workspaces-button {
+        font-size: 18px !important;
+    }
+}
 
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-workspace-icon-size="14px"]) {
-            #zen-workspaces-button {
-                font-size: 14px !important;
-            }
-        }
-
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-workspace-icon-size="16px"]) {
-            #zen-workspaces-button {
-                font-size: 16px !important;
-            }
-        }
-
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-workspace-icon-size="18px"]) {
-            #zen-workspaces-button {
-                font-size: 18px !important;
-            }
-        }
-
-        :root:has(#theme-Icon-Tweaker[icon-tweaker-workspace-icon-size="20px"]) {
-            #zen-workspaces-button {
-                font-size: 20px !important;
-            }
-        }
+:root:has(#theme-Icon-Tweaker[icon-tweaker-workspace-icon-size="20px"]) {
+    #zen-workspaces-button {
+        font-size: 20px !important;
     }
 }

--- a/theme.json
+++ b/theme.json
@@ -9,7 +9,7 @@
     "image": "https://raw.githubusercontent.com/allecsc/Icon-Tweaker/refs/heads/main/image.png",
     "author": "celalalt",
     "version": "1.1",
-  "tags": [
+    "tags": [
         "sine",
         "tabs",
         "icons",
@@ -17,5 +17,6 @@
         "resize"
     ],
     "createdAt": "2025-05-31",
-    "updatedAt": "2025-06-10"
+    "updatedAt": "2025-06-10",
+    "fork": ["zen"]
 }

--- a/theme.json
+++ b/theme.json
@@ -8,7 +8,7 @@
     "readme": "https://raw.githubusercontent.com/allecsc/Icon-Tweaker/refs/heads/main/README.md",
     "image": "https://raw.githubusercontent.com/allecsc/Icon-Tweaker/refs/heads/main/image.png",
     "author": "celalalt",
-    "version": "1.1",
+    "version": "1.2",
     "tags": [
         "sine",
         "tabs",

--- a/theme.json
+++ b/theme.json
@@ -18,5 +18,5 @@
     ],
     "createdAt": "2025-05-31",
     "updatedAt": "2025-06-16",
-    "fork": ["zen"]
+    "fork": ["zen", "firefox"]
 }

--- a/theme.json
+++ b/theme.json
@@ -17,6 +17,6 @@
         "resize"
     ],
     "createdAt": "2025-05-31",
-    "updatedAt": "2025-06-10",
+    "updatedAt": "2025-06-16",
     "fork": ["zen"]
 }


### PR DESCRIPTION
In the very near future, Sine will support all Firefox-based browsers. In light of this, Sine will be integrating a new feature to only show mods on the marketplace when the user is using that fork. In order to make use of this, I have created a pr here to do that exactly, as well as clean up some formatting.
@allecsc